### PR TITLE
Required the lodash library.

### DIFF
--- a/tasks/ejs-locals.js
+++ b/tasks/ejs-locals.js
@@ -9,10 +9,12 @@
 module.exports = function(grunt) {
   'use strict';
 
-  var ejs = require('ejs-locals');
+  var ejs = require('ejs-locals'),
+  _ = require('lodash');
 
   grunt.registerMultiTask('ejs', 'compile ejs templates', function() {
     var options = this.options();
+    options._ = _;
 
     grunt.verbose.writeflags(options, 'Options');
 


### PR DESCRIPTION
Required the lodash library.
Passed the lodash library as an option to the ejs render function.

I am not sure this is worthy of a pull request, but Lodash/underscore is often used in layouts/partials.
