### PR TITLE
Fixed bug when setting _layoutFile on expand src

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-ejs-locals",
   "description": "A Grunt task for compiling ejs templates with the taste of layouts, blocks and partials.",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "homepage": "https://github.com/ixisio/grunt-ejs-locals",
   "author": {
     "name": "Andreas Klein",

--- a/tasks/ejs-locals.js
+++ b/tasks/ejs-locals.js
@@ -12,14 +12,18 @@ module.exports = function(grunt) {
   var ejs = require('ejs-locals');
 
   grunt.registerMultiTask('ejs', 'compile ejs templates', function() {
-    var options = this.options();
-
-    grunt.verbose.writeflags(options, 'Options');
+    var scope = this;
 
     this.files.forEach(function(file) {
+      var options = scope.options();
+
+      grunt.verbose.writeflags(options, 'Options');
+
       // Pass empty settings obj (like express)
       // https://github.com/RandomEtc/ejs-locals/issues/32
-      options.settings = {};
+      if(!options.settings) {
+        options.settings = {};
+      }
 
       // Generate EJS-Locals HTML
       ejs(file.src[0], options, function(err, html) {
@@ -29,6 +33,6 @@ module.exports = function(grunt) {
         grunt.file.write(file.dest, html);
         grunt.log.ok('Wrote ' + file.dest);
       });
-    })
+    });
   });
 };


### PR DESCRIPTION
I would like to set a default layout. This could be done better but atleast this works!

``` js
grunt.initConfig({
  options: {
     settings: {
       views: path.join(__dirname, 'lib')
     },
     locals: {
       _layoutFile: path.sep + 'default-layout', // This will only apply for the first template
    },
  },
  src: ['*.ejs'],
  cwd: 'some/path',
  dest: 'build',
  expand: true,
  ext: '.html'
});
```
